### PR TITLE
Fix default PID location for FreeBSD

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -157,7 +157,11 @@ static const struct option_usage usage[] = {
 #endif
 	},
 	/** --daemon */
+#ifdef __FreeBSD__
+	{"pidfile",      0, OPT_STR,    {.str = "/var/run/ptunnel.pid"},
+#else
 	{"pidfile",      0, OPT_STR,    {.str = "/run/ptunnel.pid"},
+#endif
 #ifdef WIN32
 		"(Not available on this platform.)\n"
 #endif


### PR DESCRIPTION
When on FreeBSD, the PID file should be written to /var/run instead of /run.